### PR TITLE
`broccoli.buildModuleCss()` が、SASSが使えない環境で異常終了する問題を修正。

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ $ npm test
 
 ### broccoli-html-editor@0.1.0-beta.12 (2017年??月??日)
 
+- `broccoli.buildModuleCss()` が、SASSが使えない環境で異常終了する問題を修正。
 - その他幾つかの細かい修正。
 
 ### broccoli-html-editor@0.1.0-beta.11 (2017年1月18日)

--- a/libs/buildModuleResources.js
+++ b/libs/buildModuleResources.js
@@ -13,7 +13,12 @@ module.exports = function(broccoli){
 	var twig = require('twig');
 	var glob = require('glob');
 	var fs = require('fs');
-	var sass = require('node-sass');
+	var sass;
+	try {
+		sass = require('node-sass');
+	} catch (e) {
+		console.error('Failed to load "node-sass"', e);
+	}
 
 	/**
 	 * ドキュメントモジュール定義のスタイルを統合
@@ -48,11 +53,17 @@ module.exports = function(broccoli){
 						if( $path.match( new RegExp('\\.scss$', 'i') ) ){
 							// console.log($tmp_bin);
 
-							$tmp_bin = sass.renderSync({
-								'file': $path,
-								'data': $tmp_bin
-							});
-							$tmp_bin = $tmp_bin.css.toString();
+							try {
+								$tmp_bin = sass.renderSync({
+									'file': $path,
+									'data': $tmp_bin
+								});
+								$tmp_bin = $tmp_bin.css.toString();
+							} catch (e) {
+								console.error('Failed to process "SASS" content.', e);
+								callback(false);
+								return;
+							}
 						}
 
 						$tmp_bin = php.trim( $tmp_bin );


### PR DESCRIPTION
- 異常終了せず、 false を返すようにした。